### PR TITLE
Update Patch_Security.xml

### DIFF
--- a/Patches/Security/Patch_Security.xml
+++ b/Patches/Security/Patch_Security.xml
@@ -493,6 +493,26 @@
 					<AimingAccuracy>1.0</AimingAccuracy>
 				</value>
 			</li>
+		 	
+			<!-- ========== fillpercent replacement ========== -->
+
+			<li Class="PatchOperationReplace">
+			          <xpath>/Defs/ThingDef[
+					defName="Turret_MC" or
+					defName="NestMissile" or
+					defName="NestHMG" or
+					defName="NestAGS" or
+					defName="NestMMG" or
+					defName="RocketTurret" or
+					defName="ShardSentry" or
+					defName="SuvTurret" or
+					defName="WaveEmitter" or
+					defName="RSDummy"
+				  ]/fillPercent</xpath>
+			          <value>
+			            <fillPercent>0.85</fillPercent>
+			          </value>
+			</li>
 
 			<!-- ========== Impact Mine ========== -->
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
I noticed there was a difference in height between the normal sentry turrets and the Rimsenal turrets, so I increased the fill percent of the initial 0.75 to .85. This allowed the now 1.49 m turrets to fire through the 1.5 m embrasures.